### PR TITLE
Do not show sign-in screen when prompt=none when no user

### DIFF
--- a/identity/managers/identifier.go
+++ b/identity/managers/identifier.go
@@ -232,6 +232,11 @@ func (im *IdentifierIdentityManager) Authenticate(ctx context.Context, rw http.R
 	}
 
 	if err != nil {
+		if ar.Prompts[oidc.PromptNone] == true {
+			// Never show sign-in, directly return error.
+			return nil, err
+		}
+
 		// Build login URL.
 		query, err := url.ParseQuery(req.URL.RawQuery)
 		if err != nil {


### PR DESCRIPTION
When the identifier backend does not return a user, the error must
directly be returned to the OIDC client when prompt=none is
requested. A check for this was missing and is hereby added.