### PR TITLE
Allow to set a CA certificate for LDAPS connections

### DIFF
--- a/identifier/backends/ldap/ldap.go
+++ b/identifier/backends/ldap/ldap.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 	"stash.kopano.io/kgol/oidc-go"
@@ -304,6 +304,12 @@ func NewLDAPIdentifierBackend(
 	case "ldaps":
 		if uri.Port() == "" {
 			addr += ":636"
+		}
+		// To be able to verify the servers TLS certificate we need to set the
+		// server's hostname. (Normally tls.DialWithDialer() would take care of
+		// that, but we're not using that in LDAPIdentifierBackend.connect())
+		if !tlsConfig.InsecureSkipVerify && tlsConfig.ServerName == "" {
+			tlsConfig.ServerName = uri.Hostname()
 		}
 		isTLS = true
 	default:


### PR DESCRIPTION
This introduces the new environment variable LDAP_TLS_CACERT, which
allows to configure a CA certificate file for verifying the LDAP
server's TLS certificate.

Also the ServerName is now set properly in the TLSConfig, to allow the
verification to succeed.

Closes: #28