### PR TITLE
Add support for implicit scopes for server registered clients

### DIFF
--- a/bootstrap/backends/libregraph/libregraph.go
+++ b/bootstrap/backends/libregraph/libregraph.go
@@ -28,6 +28,7 @@ import (
 	"github.com/libregraph/lico/identifier"
 	"github.com/libregraph/lico/identifier/backends/libregraph"
 	"github.com/libregraph/lico/identity"
+	identityClients "github.com/libregraph/lico/identity/clients"
 	"github.com/libregraph/lico/identity/managers"
 )
 
@@ -84,11 +85,19 @@ func NewIdentityManager(bs bootstrap.Bootstrap) (identity.Manager, error) {
 		}
 	}
 
+	var clients *identityClients.Registry
+	if clientsRecord, ok := bs.Managers().Get("clients"); ok {
+		clients = clientsRecord.(*identityClients.Registry)
+	} else {
+		return nil, fmt.Errorf("clients manager not found but is required")
+	}
+
 	identifierBackend, identifierErr := libregraph.NewLibreGraphIdentifierBackend(
 		config.Config,
 		config.TLSClientConfig,
 		defaultURI,
 		scopedURIs,
+		clients,
 	)
 	if identifierErr != nil {
 		return nil, fmt.Errorf("failed to create identifier backend: %v", identifierErr)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -340,6 +340,7 @@ func (bs *bootstrap) setup(ctx context.Context, settings *Settings) error {
 	if err != nil {
 		return err
 	}
+	bs.managers = managers
 
 	identityManager, err := bs.setupIdentity(ctx, settings)
 	if err != nil {
@@ -371,7 +372,6 @@ func (bs *bootstrap) setup(ctx context.Context, settings *Settings) error {
 		return fmt.Errorf("failed to initialize provider metadata: %v", err)
 	}
 
-	bs.managers = managers
 	return nil
 }
 

--- a/identifier-registration.yaml.in
+++ b/identifier-registration.yaml.in
@@ -13,6 +13,8 @@ clients:
 #  - id: playground-trusted.js
 #    name: Trusted OIDC Playground
 #    trusted: yes
+#    implicit_scopes:
+#        - Implicitly.Added
 #    application_type: web
 #    redirect_uris:
 #       - https://my-host:8509/

--- a/identity/clients/models.go
+++ b/identity/clients/models.go
@@ -52,6 +52,8 @@ type ClientRegistration struct {
 	TrustedScopes []string `yaml:"trusted_scopes" json:"-"`
 	Insecure      bool     `yaml:"insecure" json:"-"`
 
+	ImplicitScopes []string `yaml:"implicit_scopes" json:"-"`
+
 	Dynamic         bool  `yaml:"-" json:"-"`
 	IDIssuedAt      int64 `yaml:"-" json:"-"`
 	SecretExpiresAt int64 `yaml:"-" json:"-"`
@@ -184,6 +186,17 @@ func (cr *ClientRegistration) SetDynamic(ctx context.Context, creator func(ctx c
 	cr.ID = DynamicStatelessClientIDPrefix + id
 	cr.Secret = secret
 
+	return nil
+}
+
+// ApplyImplicitScopes apples the associated registration's implicit scopes to
+// the provided scopes map.
+func (cr *ClientRegistration) ApplyImplicitScopes(scopes map[string]bool) error {
+	for _, scope := range cr.ImplicitScopes {
+		if scope != "" {
+			scopes[scope] = true
+		}
+	}
 	return nil
 }
 

--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -153,6 +153,14 @@ func (p *Provider) AuthorizeHandler(rw http.ResponseWriter, req *http.Request) {
 		goto done
 	}
 
+	// Inject implicit scopes set by client registration.
+	if registration, _ := p.clients.Get(req.Context(), ar.ClientID); registration != nil {
+		err = registration.ApplyImplicitScopes(ar.Scopes)
+		if err != nil {
+			p.logger.WithError(err).Debugln("failed to apply implicit scopes")
+		}
+	}
+
 	// Find session if any, ignoring errors.
 	ar.Session, err = p.getSession(req)
 	if err != nil {


### PR DESCRIPTION
This change adds the new `implicit_scopes` key to the client
registration YAML file. When set, the scopes set there are
implicitly and automatically injected into the requested
scopes list.