### PR TITLE
Fix HTTP2 support for libregraph backend connections

### DIFF
--- a/identifier/backends/libregraph/libregraph.go
+++ b/identifier/backends/libregraph/libregraph.go
@@ -275,6 +275,10 @@ func NewLibreGraphIdentifierBackend(
 		}
 	}
 
+	transport := utils.HTTPTransportWithTLSClientConfig(tlsConfig)
+	transport.MaxIdleConns = 100
+	transport.IdleConnTimeout = 30 * time.Second
+
 	b := &LibreGraphIdentifierBackend{
 		supportedScopes: supportedScopes,
 
@@ -282,12 +286,8 @@ func NewLibreGraphIdentifierBackend(
 		tlsConfig: tlsConfig,
 
 		client: &http.Client{
-			Transport: &http.Transport{
-				MaxIdleConns:    100,
-				IdleConnTimeout: 30 * time.Second,
-				TLSClientConfig: tlsConfig,
-			},
-			Timeout: 60 * time.Second,
+			Transport: transport,
+			Timeout:   60 * time.Second,
 		},
 
 		baseURLMap:          baseURLMap,


### PR DESCRIPTION
The libregraph backend did not initialize its HTTP client to be
compatible with HTTP2. This leads to connection errors when the
backend actually has HTTP2 enabled. This change initializes the
client for HTTP2 so it can be used no matter what protocol the
server supports.

Related errors look like

```
net/http: HTTP/1.x transport connection broken: malformed HTTP response
```