### PR TITLE
Fix parsing of JWKS in authorities registration YAML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.3.0
 	stash.kopano.io/kgol/kcc-go/v5 v5.0.1
 	stash.kopano.io/kgol/ksurveyclient-go v0.6.1
 	stash.kopano.io/kgol/oidc-go v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 stash.kopano.io/kgol/kcc-go/v5 v5.0.1 h1:urR9hOR6TnTKjGkzZKac/a9cA8ws1WecWLTgiYubLQw=
 stash.kopano.io/kgol/kcc-go/v5 v5.0.1/go.mod h1:0ZmjWapy3zp+TAjZI6iCrcfh+BthZbB2WM1VfhDgNB4=
 stash.kopano.io/kgol/ksurveyclient-go v0.6.1 h1:07u90TynOe1mRl3BaVWEi2JVIo8RZCxE0NM8X54ESnE=

--- a/identity/authorities/models.go
+++ b/identity/authorities/models.go
@@ -32,41 +32,41 @@ const (
 )
 
 type authorityRegistrationData struct {
-	ID            string `yaml:"id"`
-	Name          string `yaml:"name"`
-	AuthorityType string `yaml:"authority_type"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AuthorityType string `json:"authority_type"`
 
-	Iss string `yaml:"iss"`
+	Iss string `json:"iss"`
 
-	ClientID     string `yaml:"client_id"`
-	ClientSecret string `yaml:"client_secret"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
 
-	EntityID string `yaml:"entity_id"`
+	EntityID string `json:"entity_id"`
 
-	Trusted  bool  `yaml:"trusted"`
-	Insecure bool  `yaml:"insecure"`
-	Default  bool  `yaml:"default"`
-	Discover *bool `yaml:"discover"`
+	Trusted  bool  `json:"trusted"`
+	Insecure bool  `json:"insecure"`
+	Default  bool  `json:"default"`
+	Discover *bool `json:"discover"`
 
-	Scopes              []string `yaml:"scopes"`
-	ResponseType        string   `yaml:"response_type"`
-	CodeChallengeMethod string   `yaml:"code_challenge_method"`
+	Scopes              []string `json:"scopes"`
+	ResponseType        string   `json:"response_type"`
+	CodeChallengeMethod string   `json:"code_challenge_method"`
 
-	RawMetadataEndpoint      string `yaml:"metadata_endpoint"`
-	RawAuthorizationEndpoint string `yaml:"authorization_endpoint"`
+	RawMetadataEndpoint      string `json:"metadata_endpoint"`
+	RawAuthorizationEndpoint string `json:"authorization_endpoint"`
 
-	JWKS *jose.JSONWebKeySet `yaml:"jwks"`
+	JWKS *jose.JSONWebKeySet `json:"jwks"`
 
-	IdentityClaimName string `yaml:"identity_claim_name"`
+	IdentityClaimName string `json:"identity_claim_name"`
 
-	IdentityAliases       map[string]string `yaml:"identity_aliases,flow"`
-	IdentityAliasRequired bool              `yaml:"identity_alias_required"`
+	IdentityAliases       map[string]string `json:"identity_aliases"`
+	IdentityAliasRequired bool              `json:"identity_alias_required"`
 
-	EndSessionEnabled bool `yaml:"end_session_enabled"`
+	EndSessionEnabled bool `json:"end_session_enabled"`
 }
 
 type authorityRegistryData struct {
-	Authorities []*authorityRegistrationData `yaml:"authorities,flow"`
+	Authorities []*authorityRegistrationData `json:"authorities"`
 }
 
 // AuthorityRegistration defines an authority with its properties.


### PR DESCRIPTION
The autorities can have a local inline configuration for a JWKS
which is parsed using a struct which only has JSON unmarshalling
code. With this change, the YAML is first converted to JSON and
all the unmarshalling is handled by the corresponding JSON code
neatly fixing the issue.

Without this change, the inline JWKS keys are not parsed and fail
with `failed to decode public key` error message at startup.