### PR TITLE
Support loading validators from PEM encoded certificates

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -265,6 +266,7 @@ func (bs *bootstrap) initialize(settings *Settings) error {
 	bs.config.SigningKeyID = settings.SigningKid
 	bs.config.Signers = make(map[string]crypto.Signer)
 	bs.config.Validators = make(map[string]crypto.PublicKey)
+	bs.config.Certificates = make(map[string][]*x509.Certificate)
 
 	signingMethodString := settings.SigningMethod
 	bs.config.SigningMethod = jwt.GetSigningMethod(signingMethodString)
@@ -509,6 +511,13 @@ func (bs *bootstrap) setupOIDCProvider(ctx context.Context) (*oidcProvider.Provi
 	// Add all validators.
 	for id, publicKey := range bs.config.Validators {
 		err = provider.SetValidationKey(id, publicKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Add all certificates.
+	for id, certificate := range bs.config.Certificates {
+		err = provider.SetCertificate(id, certificate)
 		if err != nil {
 			return nil, err
 		}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -20,6 +20,7 @@ package bootstrap
 import (
 	"crypto"
 	"crypto/tls"
+	"crypto/x509"
 	"net/url"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -57,6 +58,7 @@ type Config struct {
 	SigningKeyID     string
 	Signers          map[string]crypto.Signer
 	Validators       map[string]crypto.PublicKey
+	Certificates     map[string][]*x509.Certificate
 
 	AccessTokenDurationSeconds        uint64
 	IDTokenDurationSeconds            uint64

--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -64,10 +64,12 @@ func (p *Provider) JwksHandler(rw http.ResponseWriter, req *http.Request) {
 		Keys: make([]jose.JSONWebKey, 0),
 	}
 	for kid, key := range validationKeys {
+		certificates, _ := p.certificates[kid]
 		keyJwk := jose.JSONWebKey{
-			Key:   key,
-			KeyID: kid,
-			Use:   "sig", // https://tools.ietf.org/html/rfc7517#section-4.2
+			Key:          key,
+			KeyID:        kid,
+			Use:          "sig", // https://tools.ietf.org/html/rfc7517#section-4.2
+			Certificates: certificates,
 		}
 		if keyJwk.Valid() {
 			jwks.Keys = append(jwks.Keys, keyJwk.Public())

--- a/oidc/provider/provider.go
+++ b/oidc/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -70,6 +71,7 @@ type Provider struct {
 	signingKeys          map[jwt.SigningMethod]*SigningKey
 	signingMethodDefault jwt.SigningMethod
 	validationKeys       map[string]crypto.PublicKey
+	certificates         map[string][]*x509.Certificate
 
 	browserStateCookiePath string
 	browserStateCookieName string
@@ -101,6 +103,7 @@ func NewProvider(c *Config) (*Provider, error) {
 
 		signingKeys:    make(map[jwt.SigningMethod]*SigningKey),
 		validationKeys: make(map[string]crypto.PublicKey),
+		certificates:   make(map[string][]*x509.Certificate),
 
 		browserStateCookiePath: c.BrowserStateCookiePath,
 		browserStateCookieName: c.BrowserStateCookieName,
@@ -355,6 +358,18 @@ func (p *Provider) GetValidationKey(id string) (crypto.PublicKey, bool) {
 func (p *Provider) getValidationKey(id string) (crypto.PublicKey, bool) {
 	vk, ok := p.validationKeys[id]
 	return vk, ok
+}
+
+// SetCertificate sets the provider certificate chain for a particular key.
+func (p *Provider) SetCertificate(id string, certificates []*x509.Certificate) error {
+	p.logger.WithFields(logrus.Fields{
+		"chain_size": len(certificates),
+		"id":         id,
+	}).Infoln("set provider certificate")
+
+	p.certificates[id] = certificates
+
+	return nil
 }
 
 // InitializeMetadata creates the accociated providers meta data document. Call


### PR DESCRIPTION
With this change, validators can be extracted from PEM encoded
certificates. The public key will be extracted and uses just like
direct public key pem files. In addition the certificate will be
returned in the x5c field of the JWK result for the particular
validator matching its id.