### PR TITLE
Allow backends to set top level ID token claims

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -44,6 +44,12 @@ const (
 	IdentifiedUserIsGuest      = "gu"
 )
 
+// Internal claim names used for special things.
+const (
+	InternalExtraIDTokenClaimsClaim     = "$lico.id.extra"
+	InternalExtraAccessTokenClaimsClaim = "$lico.at.extra"
+)
+
 // TokenType defines the token type value.
 type TokenTypeValue string
 

--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -700,7 +700,7 @@ done:
 	}
 
 	// Inject extra claims.
-	extraClaims := auth.Claims("")[0]
+	extraClaims := auth.Claims(konnect.InternalExtraAccessTokenClaimsClaim)[0]
 	if extraClaims != nil {
 		if extraClaimsMap, ok := extraClaims.(jwt.MapClaims); ok {
 			for claim, value := range extraClaimsMap {


### PR DESCRIPTION
Independ of access token claims, this change makes it possible for
backends to set top level ID token claims. The behavior is added
for the libregraph backend via extension. This change also fixes
the issue that extra claims from the access token were not added
to the ID token.