### PR TITLE
Properly handle prompt select_account and consent for external oidc

### DIFF
--- a/identifier/cookie.go
+++ b/identifier/cookie.go
@@ -145,7 +145,7 @@ func (i *Identifier) setStateCookie(rw http.ResponseWriter, scope string, state 
 	cookie := http.Cookie{
 		Name:   name,
 		Value:  value,
-		MaxAge: 60,
+		MaxAge: 600,
 
 		Path:     i.pathPrefix + "/identifier/" + scope,
 		Secure:   true,

--- a/identifier/handlers.go
+++ b/identifier/handlers.go
@@ -133,23 +133,21 @@ func (i *Identifier) handleIdentifier(rw http.ResponseWriter, req *http.Request)
 	}
 
 	switch req.Form.Get("flow") {
-	case FlowOIDC:
-		fallthrough
-	case FlowOAuth:
-		fallthrough
-	case "":
-		//  Check if there is a default authority, if so use that.
-		authority := i.authorities.Default(req.Context())
-		if authority != nil {
-			switch authority.AuthorityType {
-			case authorities.AuthorityTypeOIDC:
-				i.writeOAuth2Start(rw, req, authority)
-			case authorities.AuthorityTypeSAML2:
-				i.writeSAML2Start(rw, req, authority)
-			default:
-				i.ErrorPage(rw, http.StatusNotImplemented, "", "unknown authority type")
+	case FlowOIDC, FlowOAuth, "":
+		if req.Form.Get("identifier") != MustBeSignedIn {
+			//  Check if there is a default authority, if so use that.
+			authority := i.authorities.Default(req.Context())
+			if authority != nil {
+				switch authority.AuthorityType {
+				case authorities.AuthorityTypeOIDC:
+					i.writeOAuth2Start(rw, req, authority)
+				case authorities.AuthorityTypeSAML2:
+					i.writeSAML2Start(rw, req, authority)
+				default:
+					i.ErrorPage(rw, http.StatusNotImplemented, "", "unknown authority type")
+				}
+				return
 			}
-			return
 		}
 	}
 


### PR DESCRIPTION
The prompt values for select_account and consent need to be treated so that there is no loop. This change ensures that select_account is only handled by the external authority while consent is only handled by the internal authority. Furthermore, any external callback which yields an internal interactive identifier no longer always loops back to the external authority when coming from the external callback.