### PR TITLE
Escape LDAP filter values when constructing filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: latest
+        args: --timeout=2m
         skip-pkg-cache: true
         skip-build-cache: true
         skip-go-installation: true

--- a/identifier/backends/ldap/ldap.go
+++ b/identifier/backends/ldap/ldap.go
@@ -645,7 +645,7 @@ func (b *LDAPIdentifierBackend) baseAndGetFilterFromEntryID(entryID string) (str
 			filter := ""
 			for k, values := range values {
 				for _, value := range values {
-					filter = fmt.Sprintf("%s(%s=%s)", filter, k, value)
+					filter = fmt.Sprintf("%s(%s=%s)", filter, k, ldap.EscapeFilter(value))
 				}
 			}
 			if filter != "" {
@@ -666,5 +666,5 @@ func (b *LDAPIdentifierBackend) baseAndGetFilterFromEntryID(entryID string) (str
 
 func (b *LDAPIdentifierBackend) baseAndSearchFilterFromUsername(username string) (string, string) {
 	// Build search filter with username.
-	return b.baseDN, fmt.Sprintf(b.searchFilter, username)
+	return b.baseDN, fmt.Sprintf(b.searchFilter, ldap.EscapeFilter(username))
 }


### PR DESCRIPTION
When constructing LDAP filters for looking up users by name or ID make sure the assertion values are correctly escaped. Otherwise we might be creating invalid filters e.g. when the username contains the '(', ')', '*' or '\' character.
Or when when using a binary attribute such as 'objectGUID' in LDAP_SUB_ATTRIBUTES.