### PR TITLE
Limit oidc check session iframe postMessage hook scope

### DIFF
--- a/oidc/provider/html.go
+++ b/oidc/provider/html.go
@@ -188,7 +188,7 @@ c.u(b.B());c.u(n.substr(0,64-(d.f[1]+8&63)));c.c(d.f[0]<<3|d.f[0]>>>28);c.c(d.f[
 		window.addEventListener('message', function(event) {
 			// Only do something when receiving a message from our parent or
 			// from another window which shares our parent.
-			if (window.parent === event.source || window.parent === event.source.parent) {
+			if (window.parent === event.source || (window !== event.source && window.parent === event.source.parent)) {
 				var response = receiveMessage(event.origin, event.data);
 				event.source.postMessage(response, event.origin);
 			}


### PR DESCRIPTION
In certain cases the check session iframe might receive postMessage events from itself. This might sound strange and normally does not happen expect in cases where other scripts run in the scope of this iframe (e.g. getting injected by a browser extension). This for example happens with the 1Password browser extension which seems to communicate with itself via postMessage to itself and causes a high CPU load as an event busy loop is created.

With this change, our own processing of events is only done if the event source is not the own window (which is the only case we care about anyways).