### PR TITLE
Allow authorize requests wihout openid scope

### DIFF
--- a/oidc/payload/authentication.go
+++ b/oidc/payload/authentication.go
@@ -265,28 +265,36 @@ func (ar *AuthenticationRequest) ApplyRequestObject(roc *RequestObjectClaims, me
 
 // Validate validates the request data of the accociated authentication request.
 func (ar *AuthenticationRequest) Validate(keyFunc jwt.Keyfunc) error {
-	if _, ok := ar.Scopes[oidc.ScopeOpenID]; !ok {
-		return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "missing openid scope in request")
-	}
-
 	switch ar.RawResponseType {
 	case oidc.ResponseTypeCode:
 		// Code flow.
 		// breaks
 	case oidc.ResponseTypeCodeIDToken:
 		// Hybgrid flow.
+		if _, ok := ar.Scopes[oidc.ScopeOpenID]; !ok {
+			return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "missing openid scope in request")
+		}
 		// breaks
 	case oidc.ResponseTypeCodeToken:
 		// Hybgrid flow.
 		// breaks
 	case oidc.ResponseTypeCodeIDTokenToken:
 		// Hybgrid flow.
+		if _, ok := ar.Scopes[oidc.ScopeOpenID]; !ok {
+			return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "missing openid scope in request")
+		}
 		// breaks
 	case oidc.ResponseTypeIDToken:
 		// Implicit flow.
+		if _, ok := ar.Scopes[oidc.ScopeOpenID]; !ok {
+			return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "missing openid scope in request")
+		}
 		fallthrough
 	case oidc.ResponseTypeIDTokenToken:
 		// Implicit flow with access token.
+		if _, ok := ar.Scopes[oidc.ScopeOpenID]; !ok {
+			return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "missing openid scope in request")
+		}
 		if ar.Nonce == "" {
 			return ar.NewError(oidc.ErrorCodeOAuth2InvalidRequest, "nonce is required for implicit flow")
 		}

--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -506,8 +506,8 @@ func (p *Provider) TokenHandler(rw http.ResponseWriter, req *http.Request) {
 
 	switch tr.GrantType {
 	case oidc.GrantTypeAuthorizationCode:
-		// Create ID token when not previously requested.
-		if !ar.ResponseTypes[oidc.ResponseTypeIDToken] {
+		// Create ID token when not previously requested amd openid scope is authorized.
+		if !ar.ResponseTypes[oidc.ResponseTypeIDToken] && authorizedScopes[oidc.ScopeOpenID] {
 			idTokenString, err = p.makeIDToken(req.Context(), ar, auth, session, accessTokenString, "", signinMethod)
 			if err != nil {
 				goto done


### PR DESCRIPTION
To support oauth2 only clients, this change allows authorize requests which do not set the openid scope. The id token will not be returned in such cases.