### PR TITLE
Remove :443 from Host header for secure referrer/origin check

### DIFF
--- a/identifier/handlers.go
+++ b/identifier/handlers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -57,6 +58,14 @@ func (i *Identifier) secureHandler(handler http.Handler) http.Handler {
 		// NOTE: this does not protect from DNS rebinding. Protection for that
 		// should be added at the frontend proxy.
 		requiredHost := req.Host
+		if host, port, splitErr := net.SplitHostPort(requiredHost); splitErr == nil {
+			if port == "443" {
+				// Ignore the port 443 as it is the default port and it is
+				// usually not part of any of the urls. It might be in the
+				// request for HTTP/3 requests.
+				requiredHost = host
+			}
+		}
 
 		// This follows https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
 		for {


### PR DESCRIPTION
In certain cases the incoming request HTTP Host header might contain the port (for example for HTTP/3 requests). This makes the host/referrer check fail as those will not include this port. This change simply always strips the port from the incoming Host header if it is 443 to deal with the expected cases if the web server in from of the identifier serves requests with HTTP3 on port 443.