### PR TITLE
Fix access token sid claim when provided via lg backend

### DIFF
--- a/identifier/backends/libregraph/libregraph.go
+++ b/identifier/backends/libregraph/libregraph.go
@@ -245,7 +245,7 @@ func (u *libreGraphUser) setRequiredScopes(selectedScope string, scopeMap *order
 }
 
 func (u *libreGraphUser) sessionID() string {
-	if accessTokenClaims, ok := u.identityClaims[""].(map[string]interface{}); ok {
+	if accessTokenClaims, ok := u.identityClaims[konnect.InternalExtraAccessTokenClaimsClaim].(map[string]interface{}); ok {
 		if sessionID, withSessionID := accessTokenClaims[oidc.SessionIDClaim].(string); withSessionID {
 			if sessionID != "" {
 				return sessionID


### PR DESCRIPTION
It was discovered that when the libregraph backend provides the session id it was not correctly ending up in the access token sid claim.

This fixes the regression introduced in
401fdc1ff0dc25eba052cea29818a729336cdb10 and makes sid claim usable again.