### PR TITLE
Keep id and access token claims when using refresh tokens

### DIFF
--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -239,7 +239,7 @@ func (p *Provider) AuthorizeResponse(rw http.ResponseWriter, req *http.Request, 
 
 	// Create access token when requested.
 	if _, ok := ar.ResponseTypes[oidc.ResponseTypeToken]; ok {
-		accessTokenString, err = p.makeAccessToken(ctx, ar.ClientID, auth, nil)
+		accessTokenString, err = p.makeAccessToken(ctx, ar.ClientID, auth, nil, nil)
 		if err != nil {
 			goto done
 		}
@@ -248,7 +248,7 @@ func (p *Provider) AuthorizeResponse(rw http.ResponseWriter, req *http.Request, 
 	// Create ID token when requested and granted.
 	if authorizedScopes[oidc.ScopeOpenID] {
 		if _, ok := ar.ResponseTypes[oidc.ResponseTypeIDToken]; ok {
-			idTokenString, err = p.makeIDToken(ctx, ar, auth, session, accessTokenString, codeString, nil)
+			idTokenString, err = p.makeIDToken(ctx, ar, auth, session, accessTokenString, codeString, nil, nil)
 			if err != nil {
 				goto done
 			}
@@ -330,6 +330,7 @@ func (p *Provider) TokenHandler(rw http.ResponseWriter, req *http.Request) {
 	var accessTokenString string
 	var idTokenString string
 	var refreshTokenString string
+	var refreshTokenClaims *konnect.RefreshTokenClaims
 	var approvedScopes map[string]bool
 	var authorizedScopes map[string]bool
 	var clientDetails *clients.Details
@@ -498,13 +499,16 @@ func (p *Provider) TokenHandler(rw http.ResponseWriter, req *http.Request) {
 			ClientID: claims.Audience,
 		}
 
+		// Remember refresh token claims, for use in access and id token generators later on.
+		refreshTokenClaims = claims
+
 	default:
 		err = konnectoidc.NewOAuth2Error(oidc.ErrorCodeOAuth2UnsupportedGrantType, "grant_type value not implemented")
 		goto done
 	}
 
 	// Create access token.
-	accessTokenString, err = p.makeAccessToken(ctx, ar.ClientID, auth, signinMethod)
+	accessTokenString, err = p.makeAccessToken(ctx, ar.ClientID, auth, signinMethod, refreshTokenClaims)
 	if err != nil {
 		goto done
 	}
@@ -513,7 +517,7 @@ func (p *Provider) TokenHandler(rw http.ResponseWriter, req *http.Request) {
 	case oidc.GrantTypeAuthorizationCode, oidc.GrantTypeRefreshToken:
 		// Create ID token when not previously requested amd openid scope is authorized.
 		if !ar.ResponseTypes[oidc.ResponseTypeIDToken] && authorizedScopes[oidc.ScopeOpenID] {
-			idTokenString, err = p.makeIDToken(ctx, ar, auth, session, accessTokenString, "", signinMethod)
+			idTokenString, err = p.makeIDToken(ctx, ar, auth, session, accessTokenString, "", signinMethod, refreshTokenClaims)
 			if err != nil {
 				goto done
 			}

--- a/oidc/provider/handlers.go
+++ b/oidc/provider/handlers.go
@@ -510,7 +510,7 @@ func (p *Provider) TokenHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	switch tr.GrantType {
-	case oidc.GrantTypeAuthorizationCode:
+	case oidc.GrantTypeAuthorizationCode, oidc.GrantTypeRefreshToken:
 		// Create ID token when not previously requested amd openid scope is authorized.
 		if !ar.ResponseTypes[oidc.ResponseTypeIDToken] && authorizedScopes[oidc.ScopeOpenID] {
 			idTokenString, err = p.makeIDToken(ctx, ar, auth, session, accessTokenString, "", signinMethod)


### PR DESCRIPTION
When a identifier backend injects custom claims, those need to be carried over to access tokens and id tokens which are issued after a refresh token was exchanged via the token endpoint. This PR adds support for this by applying any extra claims recorded in the refresh token to the corresponding access and id tokens.