### PR TITLE
Allow client redirect URI with only a scheme

### DIFF
--- a/oidc/payload/authentication.go
+++ b/oidc/payload/authentication.go
@@ -332,7 +332,7 @@ func (ar *AuthenticationRequest) Validate(keyFunc jwt.Keyfunc) error {
 	}
 	// TODO(longsleep): implement client_id white list.
 
-	if ar.RedirectURI == nil || ar.RedirectURI.Host == "" || ar.RedirectURI.Scheme == "" {
+	if ar.RedirectURI == nil || !ar.RedirectURI.IsAbs() {
 		return ar.NewBadRequest(oidc.ErrorCodeOAuth2InvalidRequest, "invalid or missing redirect_uri")
 	}
 


### PR DESCRIPTION
The redirect URI can have the form `protocol:action` which is basically just a scheme. This is entirely valid and since such URI do not have a host the validation of the redirect_uri request parameter fails.

This change does no longer check the host part of the URI to be non-empty, fixing client support for clients using such URIs.

Fixes: #161