### PR TITLE
Fix CI pipeline and bump CI to use Go 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.22
 
     - name: Set up Node
       uses: actions/setup-node@v3
@@ -41,7 +41,6 @@ jobs:
         args: --timeout=2m
         skip-pkg-cache: true
         skip-build-cache: true
-        skip-go-installation: true
         only-new-issues: true
 
     - name: Build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,9 +40,9 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - funlen
     - gochecknoinits
     - goconst


### PR DESCRIPTION
Clone CI pipleine settins from idm to ensure consistent experience between the different projects. Also some linters are no longer functioning and got replaced, letting the CI pipeline succeed again.